### PR TITLE
fix: Update path_regex to match .enc.yaml files in SOPSConfigCreationRule

### DIFF
--- a/Devantler.SecretManager.SOPS.LocalAge.Tests/Utils/SOPSConfigHelperTests/CreateSOPSConfigAsyncTests.CreateSOPSConfigAsync_CreatesDirectoryAndConfigFile.verified.txt
+++ b/Devantler.SecretManager.SOPS.LocalAge.Tests/Utils/SOPSConfigHelperTests/CreateSOPSConfigAsyncTests.CreateSOPSConfigAsync_CreatesDirectoryAndConfigFile.verified.txt
@@ -1,5 +1,5 @@
 ﻿creation_rules:
-- path_regex: .sops.yaml
+- path_regex: ^.+\.enc\.ya?ml$
   encrypted_regex: ^(data|stringData)$
   age: |-
     public-key,

--- a/Devantler.SecretManager.SOPS.LocalAge.Tests/Utils/SOPSConfigHelperTests/CreateSOPSConfigAsyncTests.CreateSOPSConfigAsync_CreatesNewConfigFile.verified.txt
+++ b/Devantler.SecretManager.SOPS.LocalAge.Tests/Utils/SOPSConfigHelperTests/CreateSOPSConfigAsyncTests.CreateSOPSConfigAsync_CreatesNewConfigFile.verified.txt
@@ -1,5 +1,5 @@
 ﻿creation_rules:
-- path_regex: .sops.yaml
+- path_regex: ^.+\.enc\.ya?ml$
   encrypted_regex: ^(data|stringData)$
   age: |-
     public-key,

--- a/Devantler.SecretManager.SOPS.LocalAge.Tests/Utils/SOPSConfigHelperTests/CreateSOPSConfigAsyncTests.CreateSOPSConfigAsync_OverwritesExistingConfigFile.verified.txt
+++ b/Devantler.SecretManager.SOPS.LocalAge.Tests/Utils/SOPSConfigHelperTests/CreateSOPSConfigAsyncTests.CreateSOPSConfigAsync_OverwritesExistingConfigFile.verified.txt
@@ -1,17 +1,17 @@
 ﻿creation_rules:
-- path_regex: .sops.yaml
+- path_regex: ^.+\.enc\.ya?ml$
   encrypted_regex: ^(data|stringData)$
   age: |-
     public-key,
     public-key
 
 creation_rules:
-- path_regex: .sops.yaml
+- path_regex: ^.+\.enc\.ya?ml$
   encrypted_regex: ^(data|stringData)$
   age: |-
     public-key,
     public-key
-- path_regex: .sops.yaml
+- path_regex: ^.+\.enc\.ya?ml$
   encrypted_regex: ^(data|stringData)$
   age: |-
     public-key,

--- a/Devantler.SecretManager.SOPS.LocalAge.Tests/Utils/SOPSConfigHelperTests/CreateSOPSConfigAsyncTests.cs
+++ b/Devantler.SecretManager.SOPS.LocalAge.Tests/Utils/SOPSConfigHelperTests/CreateSOPSConfigAsyncTests.cs
@@ -25,7 +25,7 @@ public class CreateSOPSConfigAsyncTests
       [
         new SOPSConfigCreationRule
         {
-          PathRegex = ".sops.yaml",
+          PathRegex = @"^.+\.enc\.ya?ml$",
           EncryptedRegex = "^(data|stringData)$",
           Age = $"public-key,{Environment.NewLine}public-key"
         }
@@ -57,7 +57,7 @@ public class CreateSOPSConfigAsyncTests
       [
         new SOPSConfigCreationRule
         {
-          PathRegex = ".sops.yaml",
+          PathRegex = @"^.+\.enc\.ya?ml$",
           EncryptedRegex = "^(data|stringData)$",
           Age = $"public-key,{Environment.NewLine}public-key"
         }
@@ -69,7 +69,7 @@ public class CreateSOPSConfigAsyncTests
     string configFromFile = await File.ReadAllTextAsync(configPath);
     sopsConfig.CreationRules.Add(new SOPSConfigCreationRule
     {
-      PathRegex = ".sops.yaml",
+      PathRegex = @"^.+\.enc\.ya?ml$",
       EncryptedRegex = "^(data|stringData)$",
       Age = $"public-key,{Environment.NewLine}public-key"
     });
@@ -100,7 +100,7 @@ public class CreateSOPSConfigAsyncTests
       [
         new SOPSConfigCreationRule
         {
-          PathRegex = ".sops.yaml",
+          PathRegex = @"^.+\.enc\.ya?ml$",
           EncryptedRegex = "^(data|stringData)$",
           Age = $"public-key,{Environment.NewLine}public-key"
         }

--- a/Devantler.SecretManager.SOPS.LocalAge.Tests/Utils/SOPSConfigHelperTests/GetSOPSConfigAsyncTests.GetSOPSConfigAsync_GivenValidConfigPath_ReturnsSOPSConfig.verified.txt
+++ b/Devantler.SecretManager.SOPS.LocalAge.Tests/Utils/SOPSConfigHelperTests/GetSOPSConfigAsyncTests.GetSOPSConfigAsync_GivenValidConfigPath_ReturnsSOPSConfig.verified.txt
@@ -1,7 +1,7 @@
 ﻿{
   CreationRules: [
     {
-      PathRegex: .sops.yaml,
+      PathRegex: ^.+\.enc\.ya?ml$,
       EncryptedRegex: ^(data|stringData)$,
       Age:
 public-key,

--- a/Devantler.SecretManager.SOPS.LocalAge.Tests/Utils/SOPSConfigHelperTests/GetSOPSConfigAsyncTests.cs
+++ b/Devantler.SecretManager.SOPS.LocalAge.Tests/Utils/SOPSConfigHelperTests/GetSOPSConfigAsyncTests.cs
@@ -25,7 +25,7 @@ public class GetSOPSConfigAsyncTests
       [
         new SOPSConfigCreationRule
         {
-          PathRegex = ".sops.yaml",
+          PathRegex = @"^.+\.enc\.ya?ml$",
           EncryptedRegex = "^(data|stringData)$",
           Age = $"public-key,{Environment.NewLine}public-key"
         }

--- a/Devantler.SecretManager.SOPS.LocalAge/Models/SOPSConfigCreationRule.cs
+++ b/Devantler.SecretManager.SOPS.LocalAge/Models/SOPSConfigCreationRule.cs
@@ -16,7 +16,7 @@ public class SOPSConfigCreationRule
   /// <summary>
   /// The encrypted regex for the fields that is managed by this rule.
   /// </summary>
-  public string EncryptedRegex { get; set; } = "^(data | stringData)$";
+  public string EncryptedRegex { get; set; } = "^(data|stringData)$";
 
   /// <summary>
   /// The public keys that can manage the files that is managed by this rule.


### PR DESCRIPTION
Revise the path_regex in SOPSConfigCreationRule to correctly match files with the .enc.yaml extension, enhancing the configuration's accuracy.